### PR TITLE
Bug Fix: Overflow Text View; Improvement: Make Title Single Line and Ellipsize;

### DIFF
--- a/app/src/main/res/layout/movie_list_item.xml
+++ b/app/src/main/res/layout/movie_list_item.xml
@@ -39,9 +39,11 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/roboto"
-                android:textSize="@dimen/_16ssp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textSize="17sp"
                 android:textStyle="bold"
-                tools:text="Hello everyone" />
+                tools:text="@tools:sample/lorem/random" />
 
             <LinearLayout
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/movie_list_item.xml
+++ b/app/src/main/res/layout/movie_list_item.xml
@@ -111,7 +111,6 @@
                         android:layout_height="wrap_content"
                         android:background="@color/black"
                         android:paddingHorizontal="@dimen/_6sdp"
-                        android:paddingVertical="@dimen/_3sdp"
                         android:textColor="@color/white"
                         android:textSize="@dimen/_12ssp"
                         android:textStyle="bold"

--- a/app/src/main/res/layout/movie_list_item.xml
+++ b/app/src/main/res/layout/movie_list_item.xml
@@ -41,7 +41,7 @@
                 android:fontFamily="@font/roboto"
                 android:maxLines="1"
                 android:ellipsize="end"
-                android:textSize="17sp"
+                android:textSize="@dimen/_16ssp"
                 android:textStyle="bold"
                 tools:text="@tools:sample/lorem/random" />
 


### PR DESCRIPTION
## Description

* Bug fix: overflow text view "ADD TO LIST".
* Improvement : make title into single line and make it ellipsize whenever text reach the view itself.

## Issue Resolved
Issue https://github.com/PEC-CSS/MovieDroid/issues/88 : RESOLVED ✅ 

## Screenshots 
Tested on AVD Nexus 5 (360 x 640 dp, XXHDPI) ✅ 
<img src="https://user-images.githubusercontent.com/23600466/198839678-351437ba-dba1-49dd-875a-4b0e84cd04b8.png" width="360" height="640">

### Another Preview on Generic AVD
| Screen      | Size |
| ----------- | ----------- |
| 2.7" (320 x 427 dp, LDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839174-4e30f8bc-654b-4a67-a2f2-ff29d490ec74.png" width="320" height="427"> |
| 3.2" (320 x 480 dp, MDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839269-7767d35d-2b11-4f32-af01-02b52bf86a40.png" width="320" height="480"> |
| 3.3" (320 x 533 dp, LDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839396-20524fa5-be64-46c3-b5df-4f67adb03aed.png" width="320" height="533"> |
| 3.4" (320 x 576  dp, LDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839443-bf2e9a98-f335-48a7-b11f-f8d5e1e3dae5.png" width="320" height="576"> |
| 3.7" - NEXUS ONE (320 x 533 dp, HDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839471-0663b93c-1a2b-420a-a9bf-a49fb4b30a7d.png" width="320" height="533"> |
| 4.7" (640 x 360 dp, XHDPI) | <img src="https://user-images.githubusercontent.com/23600466/198839554-7a916324-6992-49b1-8813-ebe43368a119.png" width="320" height="533"> |

## Checklist

Please make sure to review the following before submitting your PR: 
<!---To check the points, put a 'x' in the boxes below -->

- [x] I have read the [contribution guidelines](https://github.com/PEC-CSS/MovieDroid/blob/main/CONTRIBUTING.md).
- [x] I have read the code of conduct.
- [x] I have reviewed my submission in detail. 
