### PR TITLE
apk release automated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        type: boolean
+        required: false
+        default: false
+      release_name:
+        type: string
+        required: false
+
+jobs:
+  apk:
+    permissions:
+      contents: write
+    name: Generate and Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          cache: gradle
+      - name: Set execution flag for gradlew
+        run: chmod +x gradlew
+      - name: Run unit tests
+        run: ./gradlew test
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Build APK
+        run: ./gradlew assembleRelease
+      - name: Sign app APK
+        uses: r0adkll/sign-android-release@v1
+        id: sign_app
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "30.0.2"
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: ${{steps.sign_app.outputs.signedReleaseFile}}
+      - uses: marvinpinto/action-automatic-releases@latest
+        id: create_release
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          title: ${{ inputs.release_name }}
+          draft: false
+          prerelease: ${{ inputs.prerelease }}
+      - name: upload apk
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{steps.sign_app.outputs.signedReleaseFile}}
+          asset_name: MovieDroid.apk
+          asset_content_type: application/zip


### PR DESCRIPTION
## Description

added a release_draft workflow. which creates a draft with signed apk of the app.

## Issue Resolved

closes #136 

## Steps to follow:
1. open android studio -> build -> generate signed bundle/apk -> apk -> create new. remember the credentials
2. convert the newly generated jsk file to base64 string using any [online tool](https://base64.guru/converter/encode/file).
3. on github, go to settings -> secrets and variables -> actions -> new repo secret. 
![image](https://user-images.githubusercontent.com/66007619/220191661-fdf8a87c-bbfb-49fb-8725-7ba17e9c80a4.png)
create all these, signing_key is the base64 string.
4. in your terminal run the command `keytool -list -v -keystore {jsk file path} -alias {alias}`
5. enter passwords and copy the sha1 and sha256 fingerprints and add them to your firebase console.
### ez

## Checklist

Please make sure to review the following before submitting your PR: 
<!---To check the points, put a 'x' in the boxes below -->

- [x] I have read the [contribution guidelines](https://github.com/PEC-CSS/MovieDroid/blob/main/CONTRIBUTING.md).
- [x] I have read the code of conduct.
- [x] I have reviewed my submission in detail. 
